### PR TITLE
Add basic menu for custom UI

### DIFF
--- a/src/00/base.asm
+++ b/src/00/base.asm
@@ -41,6 +41,7 @@ drawHexHL   .equ 0x0E01
 #include "display.asm"
 #include "display-color.asm"
 #include "keyboard.asm"
+#include "menu.asm"
 #include "link.asm"
 
 #include "crc.asm"

--- a/src/00/boot.asm
+++ b/src/00/boot.asm
@@ -115,6 +115,8 @@ reboot:
     call initDisplay
     call initIO
 
+    call mainMenu
+
     ld de, init
     call fileExists
     ld a, panic_init_not_found

--- a/src/00/menu.asm
+++ b/src/00/menu.asm
@@ -1,0 +1,63 @@
+; Simple menu system for demonstrating custom UI hooks
+; Provides a basic main menu with navigation to a sub menu
+
+mainMenu:
+    call getLCDLock
+    call getKeypadLock
+    call allocScreenBuffer
+    call clearBuffer
+    ld de, 0
+    ld b, 0
+    ld hl, menu_main
+    rst 0x20
+    .dw drawStr
+    rst 0x20
+    .dw fastCopy
+.mainLoop:
+    call waitKey
+    cp k1
+    jr z, subMenu
+    cp k2
+    jr z, exitMenu
+    jr .mainLoop
+
+subMenu:
+    call clearBuffer
+    ld de, 0
+    ld b, 0
+    ld hl, menu_sub
+    rst 0x20
+    .dw drawStr
+    rst 0x20
+    .dw fastCopy
+.subLoop:
+    call waitKey
+    cp k0
+    jr z, redrawMain
+    jr .subLoop
+
+redrawMain:
+    call clearBuffer
+    ld de, 0
+    ld b, 0
+    ld hl, menu_main
+    rst 0x20
+    .dw drawStr
+    rst 0x20
+    .dw fastCopy
+    jr .mainLoop
+
+exitMenu:
+    call freeScreenBuffer
+    call flushkeys
+    xor a
+    ld (hwLockLCD), a
+    ld (hwLockKeypad), a
+    ret
+
+menu_main:
+    .db "Main Menu\n1) Sub Menu\n2) Continue", 0
+
+menu_sub:
+    .db "Sub Menu\n0) Back", 0
+

--- a/src/boot/base.asm
+++ b/src/boot/base.asm
@@ -2,7 +2,7 @@
 ; Dummy boot page to get emulators to boot the OS
     jr _
     .fill 0x0F - $
-    .db "Emulated", 0
+    .db "Hello World!", 0
 _:
     in a, (PORT_FLASHRAMSIZE)
     


### PR DESCRIPTION
## Summary
- include a new menu module for basic UI navigation
- invoke the menu during boot to allow jumping to a sub-menu and back

## Testing
- `make` *(fails: mkrom: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689bf957b1dc832c959bfd361c681035